### PR TITLE
Spixconv

### DIFF
--- a/spixconv/server/db/SPIxCONV_NLK_OnAxis.db
+++ b/spixconv/server/db/SPIxCONV_NLK_OnAxis.db
@@ -29,6 +29,20 @@ record(ao, "$(PREFIX):Voltage-SP"){
     field(PREC, "1")    # Display Precision
     field(SCAN, "Passive")
     field(FLNK, "$(PREFIX):Voltage-BAK")
+    #-------------------------------------------
+    # alarms configuration
+    field(HHSV, "MAJOR")
+    field(HSV, "MINOR")
+    field(LSV, "MINOR")
+    field(LLSV, "MAJOR")
+    field(DRVH, "$(VOLTAGE_FACTOR)0")
+    field(DRVL, "0")
+    field(HOPR, "$(VOLTAGE_FACTOR)0")
+    field(LOPR, "0")
+    field(HIHI, "$(VOLTAGE_FACTOR)0")
+    field(HIGH, "$(VOLTAGE_FACTOR)0")
+    field(LOW, "0")
+    field(LOLO, "0")
 }
 #==================
 # Voltage Reference
@@ -176,6 +190,20 @@ record(ao, "$(PREFIX):RawVoltage-SP") {
     field(SCAN, "Passive")
 #    field(HOPR, "10.0")
 #    field(LOPR, "-10.0")
+    #-------------------------------------------
+    # alarms configuration
+    field(HHSV, "MAJOR")
+    field(HSV, "MINOR")
+    field(LSV, "MINOR")
+    field(LLSV, "MAJOR")
+    field(DRVH, "$(VOLTAGE_FACTOR)0")
+    field(DRVL, "0")
+    field(HOPR, "$(VOLTAGE_FACTOR)0")
+    field(LOPR, "0")
+    field(HIHI, "$(VOLTAGE_FACTOR)0")
+    field(HIGH, "$(VOLTAGE_FACTOR)0")
+    field(LOW, "0")
+    field(LOLO, "0")
 }
 #------------------------------------------------------------------------------
 record(ai, "$(PREFIX):Voltage-RB") {

--- a/spixconv/server/db/SPIxCONV_NLK_OnAxis.db
+++ b/spixconv/server/db/SPIxCONV_NLK_OnAxis.db
@@ -224,6 +224,20 @@ record(ai, "$(PREFIX):Voltage-RB") {
     field(PINI, "YES")                          # Process at Initialization
     field(PREC, "1")                            # Display Precision
     field(SCAN, "$(SCAN_RATE)")                 # Scanning Rate
+    #-------------------------------------------
+    # alarms configuration
+    field(HHSV, "MAJOR")
+    field(HSV, "MINOR")
+    field(LSV, "MINOR")
+    field(LLSV, "MAJOR")
+    field(DRVH, "$(VOLTAGE_FACTOR)0")
+    field(DRVL, "0")
+    field(HOPR, "$(VOLTAGE_FACTOR)0")
+    field(LOPR, "0")
+    field(HIHI, "$(VOLTAGE_FACTOR)0")
+    field(HIGH, "$(VOLTAGE_FACTOR)0")
+    field(LOW, "0")
+    field(LOLO, "0")
 }
 #==============================================================================
 #   ANALOG IN
@@ -248,6 +262,20 @@ record(ai, "$(PREFIX):Voltage-Mon") {
     field(PREC, "1")                            # Display Precision
     field(SCAN, "$(SCAN_RATE)")                 # Scanning Rate
     field(SMOO, "0.5")                          # Smoothing factor from 0 to 1 (0: no smoothing; 1: value never change)
+    #-------------------------------------------
+    # alarms configuration
+    field(HHSV, "MAJOR")
+    field(HSV, "MINOR")
+    field(LSV, "MINOR")
+    field(LLSV, "MAJOR")
+    field(DRVH, "$(VOLTAGE_FACTOR)0")
+    field(DRVL, "0")
+    field(HOPR, "$(VOLTAGE_FACTOR)0")
+    field(LOPR, "0")
+    field(HIHI, "$(VOLTAGE_FACTOR)0")
+    field(HIGH, "$(VOLTAGE_FACTOR)0")
+    field(LOW, "0")
+    field(LOLO, "0")
 }
 #==============================================================================
 #   DIGITAL PORT A

--- a/spixconv/server/db/SPIxCONV_kicker.db
+++ b/spixconv/server/db/SPIxCONV_kicker.db
@@ -223,6 +223,20 @@ record(ai, "$(PREFIX):Voltage-RB") {
     field(PINI, "YES")                          # Process at Initialization
     field(PREC, "1")                            # Display Precision
     field(SCAN, "$(SCAN_RATE)")                 # Scanning Rate
+    #-------------------------------------------
+    # alarms configuration
+    field(HHSV, "MAJOR")
+    field(HSV, "MINOR")
+    field(LSV, "MINOR")
+    field(LLSV, "MAJOR")
+    field(DRVH, "$(VOLTAGE_FACTOR)0")
+    field(DRVL, "0")
+    field(HOPR, "$(VOLTAGE_FACTOR)0")
+    field(LOPR, "0")
+    field(HIHI, "$(VOLTAGE_FACTOR)0")
+    field(HIGH, "$(VOLTAGE_FACTOR)0")
+    field(LOW, "0")
+    field(LOLO, "0")
 }
 #==============================================================================
 #   ANALOG IN
@@ -247,6 +261,20 @@ record(ai, "$(PREFIX):Voltage-Mon") {
     field(PREC, "1")                            # Display Precision
     field(SCAN, "$(SCAN_RATE)")                 # Scanning Rate
     field(SMOO, "0.5")                          # Smoothing factor from 0 to 1 (0: no smoothing; 1: value never change)
+    #-------------------------------------------
+    # alarms configuration
+    field(HHSV, "MAJOR")
+    field(HSV, "MINOR")
+    field(LSV, "MINOR")
+    field(LLSV, "MAJOR")
+    field(DRVH, "$(VOLTAGE_FACTOR)0")
+    field(DRVL, "0")
+    field(HOPR, "$(VOLTAGE_FACTOR)0")
+    field(LOPR, "0")
+    field(HIHI, "$(VOLTAGE_FACTOR)0")
+    field(HIGH, "$(VOLTAGE_FACTOR)0")
+    field(LOW, "0")
+    field(LOLO, "0")
 }
 #==============================================================================
 #   DIGITAL PORT A

--- a/spixconv/server/db/SPIxCONV_kicker.db
+++ b/spixconv/server/db/SPIxCONV_kicker.db
@@ -28,6 +28,20 @@ record(ao, "$(PREFIX):Voltage-SP"){
     field(PREC, "1")    # Display Precision
     field(SCAN, "Passive")
     field(FLNK, "$(PREFIX):Voltage-BAK")
+    #-------------------------------------------
+    # alarms configuration
+    field(HHSV, "MAJOR")
+    field(HSV, "MINOR")
+    field(LSV, "MINOR")
+    field(LLSV, "MAJOR")
+    field(DRVH, "$(VOLTAGE_FACTOR)0")
+    field(DRVL, "0")
+    field(HOPR, "$(VOLTAGE_FACTOR)0")
+    field(LOPR, "0")
+    field(HIHI, "$(VOLTAGE_FACTOR)0")
+    field(HIGH, "$(VOLTAGE_FACTOR)0")
+    field(LOW, "0")
+    field(LOLO, "0")
 }
 #==================
 # Voltage Reference
@@ -175,6 +189,20 @@ record(ao, "$(PREFIX):RawVoltage-SP") {
     field(SCAN, "Passive")
 #    field(HOPR, "10.0")
 #    field(LOPR, "-10.0")
+    #-------------------------------------------
+    # alarms configuration
+    field(HHSV, "MAJOR")
+    field(HSV, "MINOR")
+    field(LSV, "MINOR")
+    field(LLSV, "MAJOR")
+    field(DRVH, "$(VOLTAGE_FACTOR)0")
+    field(DRVL, "0")
+    field(HOPR, "$(VOLTAGE_FACTOR)0")
+    field(LOPR, "0")
+    field(HIHI, "$(VOLTAGE_FACTOR)0")
+    field(HIGH, "$(VOLTAGE_FACTOR)0")
+    field(LOW, "0")
+    field(LOLO, "0")
 }
 #------------------------------------------------------------------------------
 record(ai, "$(PREFIX):Voltage-RB") {

--- a/spixconv/server/db/SPIxCONV_septum.db
+++ b/spixconv/server/db/SPIxCONV_septum.db
@@ -28,6 +28,20 @@ record(ao, "$(PREFIX):Voltage-SP"){
     field(PREC, "1")    # Display Precision
     field(SCAN, "Passive")
     field(FLNK, "$(PREFIX):Voltage-BAK")
+    #-------------------------------------------
+    # alarms configuration
+    field(HHSV, "MAJOR")
+    field(HSV, "MINOR")
+    field(LSV, "MINOR")
+    field(LLSV, "MAJOR")
+    field(DRVH, "$(VOLTAGE_FACTOR)0")
+    field(DRVL, "0")
+    field(HOPR, "$(VOLTAGE_FACTOR)0")
+    field(LOPR, "0")
+    field(HIHI, "$(VOLTAGE_FACTOR)0")
+    field(HIGH, "$(VOLTAGE_FACTOR)0")
+    field(LOW, "0")
+    field(LOLO, "0")
 }
 #==================
 # Voltage Reference
@@ -175,6 +189,20 @@ record(ao, "$(PREFIX):RawVoltage-SP") {
     field(SCAN, "Passive")
 #    field(HOPR, "10.0")
 #    field(LOPR, "-10.0")
+    #-------------------------------------------
+    # alarms configuration
+    field(HHSV, "MAJOR")
+    field(HSV, "MINOR")
+    field(LSV, "MINOR")
+    field(LLSV, "MAJOR")
+    field(DRVH, "$(VOLTAGE_FACTOR)0")
+    field(DRVL, "0")
+    field(HOPR, "$(VOLTAGE_FACTOR)0")
+    field(LOPR, "0")
+    field(HIHI, "$(VOLTAGE_FACTOR)0")
+    field(HIGH, "$(VOLTAGE_FACTOR)0")
+    field(LOW, "0")
+    field(LOLO, "0")
 }
 #------------------------------------------------------------------------------
 record(ai, "$(PREFIX):Voltage-RB") {

--- a/spixconv/server/db/SPIxCONV_septum.db
+++ b/spixconv/server/db/SPIxCONV_septum.db
@@ -223,6 +223,20 @@ record(ai, "$(PREFIX):Voltage-RB") {
     field(PINI, "YES")                          # Process at Initialization
     field(PREC, "1")                            # Display Precision
     field(SCAN, "$(SCAN_RATE)")                 # Scanning Rate
+    #-------------------------------------------
+    # alarms configuration
+    field(HHSV, "MAJOR")
+    field(HSV, "MINOR")
+    field(LSV, "MINOR")
+    field(LLSV, "MAJOR")
+    field(DRVH, "$(VOLTAGE_FACTOR)0")
+    field(DRVL, "0")
+    field(HOPR, "$(VOLTAGE_FACTOR)0")
+    field(LOPR, "0")
+    field(HIHI, "$(VOLTAGE_FACTOR)0")
+    field(HIGH, "$(VOLTAGE_FACTOR)0")
+    field(LOW, "0")
+    field(LOLO, "0")
 }
 
 #==============================================================================
@@ -248,6 +262,20 @@ record(ai, "$(PREFIX):Voltage-Mon") {
     field(PREC, "1")                            # Display Precision
     field(SCAN, "$(SCAN_RATE)")                 # Scanning Rate
     field(SMOO, "0.5")                          # Smoothing factor from 0 to 1 (0: no smoothing; 1: value never change)
+    #-------------------------------------------
+    # alarms configuration
+    field(HHSV, "MAJOR")
+    field(HSV, "MINOR")
+    field(LSV, "MINOR")
+    field(LLSV, "MAJOR")
+    field(DRVH, "$(VOLTAGE_FACTOR)0")
+    field(DRVL, "0")
+    field(HOPR, "$(VOLTAGE_FACTOR)0")
+    field(LOPR, "0")
+    field(HIHI, "$(VOLTAGE_FACTOR)0")
+    field(HIGH, "$(VOLTAGE_FACTOR)0")
+    field(LOW, "0")
+    field(LOLO, "0")
 }
 #==============================================================================
 #   DIGITAL PORT A

--- a/spixconv/server/protocol/SPIxCONV.proto
+++ b/spixconv/server/protocol/SPIxCONV.proto
@@ -43,6 +43,12 @@ set_analog_output{
 #==============================================================================
 read_analog_output{
     InTerminator = CR LF;
+    @init{
+        # output parameters: board
+        out 0x03, $1;
+        # input parameters:  code set
+        in "%u";
+    }
     # output parameters: board
     out 0x03, $1;
     # input parameters:  code set
@@ -90,6 +96,13 @@ read_portB_digital_output_bit{
 }
 #==============================================================================
 set_portB_digital_output_bit{
+    @init{
+        # output parameters: board, bit
+        out 0x0B, $1, $2;
+        # input parameters:  bit read
+        in "%u";
+    }
+
     # output parameters: board, bit, value
     out 0x0C, $1, $2, "%(RVAL)i";
 }


### PR DESCRIPTION
Added alarms for "Voltage-SP", "Voltage-RB" and "Voltage-Mon" EPICS PVs.
Added initial read of value implemented in hardware for "Voltage-SP" PV during IOC initialization.